### PR TITLE
[WIP] Pass selected category from DiscoverScreen to SearchResultsScreen

### DIFF
--- a/screens/SearchResultsScreen.js
+++ b/screens/SearchResultsScreen.js
@@ -15,20 +15,23 @@ import { faSortDown } from "@fortawesome/free-solid-svg-icons";
 import ResultTile from "../components/ResultTile";
 
 export default function SearchResultsScreen({ navigation, route }) {
-  const { searchInput } = route.params;
+  const { searchInput } = route.params || null;
+  const { category } = navigation.dangerouslyGetState().routes[1].params || "";
   const [businesses, setBusinesses] = useState([]);
   const [filteredBusinesses, setFilteredBusinesses] = useState([]);
 
   const categoryData = [
+    { label: "All categories", value: "" },
     { label: "Hospitality", value: "hospitality" },
     { label: "Retail", value: "retail" },
-    { label: "Health and Wellbeing", value: "health-wellbeing" },
+    { label: "Health and Wellbeing", value: "health and wellbeing" },
     { label: "Services", value: "services" },
     { label: "Other", value: "other" }
   ];
 
   const nearestToMeData = [{ label: "Date added", value: "date-added" }];
 
+  // Fetch data from API
   useEffect(() => {
     const fetchBusinesses = async () => {
       const results = await fetch(
@@ -41,13 +44,23 @@ export default function SearchResultsScreen({ navigation, route }) {
     fetchBusinesses();
   }, [setBusinesses]);
 
+  // Update category dropdown if selected from DiscoverScreen
+  useEffect(() => {
+    const updateCategoryDropDown = async () => {
+      if (category) {
+        handleCategoryChange(category);
+      }
+    };
+    updateCategoryDropDown();
+  }, [businesses, category]);
+
   const handleCategoryChange = selectedCategory => {
     // If there's a selected category, filter on its name
     // Else return all businesses
     if (selectedCategory) {
-      const filtered = businesses.filter(
-        business => business.categories[0].name == selectedCategory
-      );
+      const filtered = businesses.filter(business => {
+        return business.categories[0].name == selectedCategory.toLowerCase();
+      });
       setFilteredBusinesses(filtered);
     } else {
       setFilteredBusinesses(businesses);
@@ -61,26 +74,26 @@ export default function SearchResultsScreen({ navigation, route }) {
         <View style={styles.dropDownContainer}>
           <View style={styles.dropDown}>
             <RNPickerSelect
-              style={pickerSelectStyles}
-              onValueChange={e => handleCategoryChange(e)}
-              items={categoryData}
-              placeholder={{ label: "All categories", value: null }}
+              placeholder={{}}
               placeholderTextColor="#3F3356"
+              items={categoryData}
+              onValueChange={value => handleCategoryChange(value)}
               Icon={() => {
                 return <FontAwesomeIcon icon={faSortDown} color={"#3F3356"} />;
               }}
+              style={pickerSelectStyles}
             />
           </View>
           <View style={styles.dropDown}>
             <RNPickerSelect
-              style={pickerSelectStyles}
-              onValueChange={value => console.log(value)}
-              items={nearestToMeData}
               placeholder={{ label: "Nearest to me", value: "nearest-to-me" }}
               placeholderTextColor="#3F3356"
+              items={nearestToMeData}
+              onValueChange={value => console.log(value)}
               Icon={() => {
                 return <FontAwesomeIcon icon={faSortDown} color={"#3F3356"} />;
               }}
+              style={pickerSelectStyles}
             />
           </View>
         </View>


### PR DESCRIPTION
## High-level overview

This PR adds a new `useEffect` method on the SRP that checks to see if a category was selected. If so, it triggers the `handleCategoryChange()` method which updates the filtered list of businesses.

## Callouts

- Still trying to work out how to update the actual dropdown value to be the selected category. The `react-native-picker-select` library isn't playing nice. 😢 

## Preview

![pass-data-srp](https://user-images.githubusercontent.com/16424236/78417051-eeef4500-7679-11ea-83c7-ee8e5c83e08a.gif)

## Resources

- [Expo Snack - react-native-picker-select](https://snack.expo.io/@lfkwtz/react-native-picker-select)