### PR TITLE
Update styles and add Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+.gitignore
+.vscode/
+node_modules/
+.expo/
+.expo-shared/

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,19 @@
+"use strict";
+
+module.exports = {
+  arrowParens: "avoid",
+  bracketSpacing: true,
+  endOfLine: "lf",
+  htmlWhitespaceSensitivity: "css",
+  jsxBracketSameLine: false,
+  jsxSingleQuote: true,
+  loglevel: "warn",
+  printWidth: 80,
+  proseWrap: "always",
+  quoteProps: "as-needed",
+  semi: true,
+  singleQuote: false,
+  tabWidth: 2,
+  trailingComma: "all",
+  useTabs: false,
+};

--- a/components/ResultTile.js
+++ b/components/ResultTile.js
@@ -1,22 +1,37 @@
-import React from 'react';
-import { View, Text, Image, ImageBackground, StyleSheet } from 'react-native';
+import React from "react";
+import { View, Text, Image, ImageBackground, StyleSheet } from "react-native";
 
-const headerImage = { uri: "https://www.adpstore.com.au/wp-content/uploads/2017/08/shop-layout-1440x961.jpg" }
-const categoryImage = { uri: "https://carrythroughcovid.s3-ap-southeast-2.amazonaws.com/icons/cheeseburger.png" }
+const headerImage = {
+  uri:
+    "https://www.adpstore.com.au/wp-content/uploads/2017/08/shop-layout-1440x961.jpg"
+};
+const categoryImage = {
+  uri:
+    "https://carrythroughcovid.s3-ap-southeast-2.amazonaws.com/icons/cheeseburger.png"
+};
 
-const ResultTile = ({ name, suburb, category, description = "Some quick high-level description about the business." }) => (
-  <View style={styles.container}>
-    <ImageBackground source={headerImage} style={styles.image} />
-    {suburb && <View style={styles.suburb}>
-      <Text style={styles.suburbText}>{suburb}</Text>
-    </View>}
-    <View style={styles.bottomWrapper}>
-      <View style={styles.category}>
-        <Image style={styles.categoryImage} source={categoryImage} />
-      </View>
-      <View style={styles.bottomContainer}>
-        <Text style={styles.title}>{name}</Text>
-        <Text style={styles.subTitle}>{description}</Text>
+const ResultTile = ({
+  name,
+  suburb,
+  category,
+  description = "Some quick high-level description about the business."
+}) => (
+  <View style={styles.shadow}>
+    <View style={styles.container}>
+      <ImageBackground source={headerImage} style={styles.image} />
+      {suburb && (
+        <View style={styles.suburb}>
+          <Text style={styles.suburbText}>{suburb}</Text>
+        </View>
+      )}
+      <View style={styles.bottomWrapper}>
+        <View style={styles.category}>
+          <Image style={styles.categoryImage} source={categoryImage} />
+        </View>
+        <View style={styles.bottomContainer}>
+          <Text style={styles.title}>{name}</Text>
+          <Text style={styles.subTitle}>{description}</Text>
+        </View>
       </View>
     </View>
   </View>
@@ -24,69 +39,78 @@ const ResultTile = ({ name, suburb, category, description = "Some quick high-lev
 
 const styles = StyleSheet.create({
   container: {
-    overflow: 'hidden',
+    overflow: "hidden",
     borderRadius: 5,
     elevation: 5,
-    position: 'relative',
+    position: "relative"
   },
   bottomWrapper: {
-    backgroundColor: 'white',
+    backgroundColor: "white",
     paddingBottom: 30,
-    display: 'flex',
-    alignItems: 'center',
+    display: "flex",
+    alignItems: "center"
   },
   bottomContainer: {
-    display: 'flex',
-    alignItems: 'center',
-    maxWidth: '80%',
-    marginLeft: 'auto',
-    marginRight: 'auto',
+    display: "flex",
+    alignItems: "center",
+    maxWidth: "80%",
+    marginLeft: "auto",
+    marginRight: "auto"
   },
   image: {
     resizeMode: "cover",
-    minHeight: 150,
+    minHeight: 150
+  },
+  shadow: {
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.2,
+    shadowRadius: 10
   },
   text: {
-    padding: 20,
+    padding: 20
   },
   title: {
-    fontSize: 20,
+    fontSize: 20
   },
   subTitle: {
-    textAlign: 'center',
-    paddingTop: 10,
+    textAlign: "center",
+    paddingTop: 10
   },
   categoryImage: {
     width: 40,
     height: 40,
-    transform: [{ translateY: -2 }],
+    transform: [{ translateY: -2 }]
   },
   category: {
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
     width: 80,
     height: 80,
-    backgroundColor: '#F2F2F2',
+    backgroundColor: "#F2F2F2",
     marginTop: -40,
     borderRadius: 50,
-    borderColor: 'white',
-    borderWidth: 5,
+    borderColor: "white",
+    borderWidth: 5
   },
   suburb: {
-    position: 'absolute',
+    position: "absolute",
     top: 15,
     left: 15,
     paddingTop: 5,
     paddingBottom: 5,
     paddingLeft: 10,
     paddingRight: 10,
-    backgroundColor: '#BE52F2',
-    borderRadius: 5,
+    backgroundColor: "#BE52F2",
+    borderRadius: 5
   },
   suburbText: {
-    color: 'white',
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    fontSize: 11,
+    color: "white"
   }
-})
+});
 
 export default ResultTile;

--- a/navigation/TabNavigator.js
+++ b/navigation/TabNavigator.js
@@ -1,21 +1,26 @@
-import * as React from 'react';
-import { NavigationContainer } from '@react-navigation/native';
-import { createStackNavigator } from '@react-navigation/stack';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import * as React from "react";
+import { NavigationContainer } from "@react-navigation/native";
+import { createStackNavigator } from "@react-navigation/stack";
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 
-import DiscoverScreen from '../screens/DiscoverScreen';
-import SearchResultsScreen from '../screens/SearchResultsScreen';
-import DetailsScreen from '../screens/DetailsScreen';
-import AboutScreen from '../screens/AboutScreen';
+import DiscoverScreen from "../screens/DiscoverScreen";
+import SearchResultsScreen from "../screens/SearchResultsScreen";
+import DetailsScreen from "../screens/DetailsScreen";
+import AboutScreen from "../screens/AboutScreen";
+
+import FeatherIcon from "react-native-vector-icons/Feather";
 
 const DiscoverStack = createStackNavigator();
 
 function DiscoverStackScreen() {
   return (
     <DiscoverStack.Navigator>
-      <DiscoverStack.Screen name="Discover" component={DiscoverScreen} />
-      <DiscoverStack.Screen name="SearchResults" component={SearchResultsScreen} />
-      <DiscoverStack.Screen name="Details" component={DetailsScreen} />
+      <DiscoverStack.Screen name='Discover' component={DiscoverScreen} />
+      <DiscoverStack.Screen
+        name='SearchResults'
+        component={SearchResultsScreen}
+      />
+      <DiscoverStack.Screen name='Details' component={DetailsScreen} />
     </DiscoverStack.Navigator>
   );
 }
@@ -25,7 +30,7 @@ const AboutStack = createStackNavigator();
 function AboutStackScreen() {
   return (
     <AboutStack.Navigator>
-      <AboutStack.Screen name="Settings" component={AboutScreen} />
+      <AboutStack.Screen name='About' component={AboutScreen} />
     </AboutStack.Navigator>
   );
 }
@@ -36,8 +41,26 @@ export default function App() {
   return (
     <NavigationContainer>
       <Tab.Navigator>
-        <Tab.Screen name="Discover" component={DiscoverStackScreen} />
-        <Tab.Screen name="About" component={AboutStackScreen} />
+        <Tab.Screen
+          name='Discover'
+          component={DiscoverStackScreen}
+          options={{
+            tabBarLabel: "Discover",
+            tabBarIcon: () => (
+              <FeatherIcon name='search' color={"#1A051D"} size={20} />
+            ),
+          }}
+        />
+        <Tab.Screen
+          name='About'
+          component={AboutStackScreen}
+          options={{
+            tabBarLabel: "About",
+            tabBarIcon: () => (
+              <FeatherIcon name='info' color={"#1A051D"} size={20} />
+            ),
+          }}
+        />
       </Tab.Navigator>
     </NavigationContainer>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -7589,6 +7589,11 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.2.tgz",
+      "integrity": "sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg=="
+    },
     "pretty-format": {
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1115,15 +1115,6 @@
         "@fortawesome/fontawesome-common-types": "^0.2.28"
       }
     },
-    "@fortawesome/react-native-fontawesome": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-native-fontawesome/-/react-native-fontawesome-0.2.3.tgz",
-      "integrity": "sha512-kwzuPtpJC2jLnJetdBytlSjZ32rH55hr5Uk96uh3M7B2e4B8HoTpJmeXP3nXYbZMxu3eVJ5WHxPwQbP92W6Xkw==",
-      "requires": {
-        "humps": "^2.0.1",
-        "prop-types": "^15.7.2"
-      }
-    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -4600,11 +4591,6 @@
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
       }
-    },
-    "humps": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-      "integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao="
     },
     "hyphenate-style-name": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "expo-font": "~8.0.0",
     "expo-web-browser": "~8.0.0",
     "lodash": "^4.17.15",
+    "prettier": "^2.0.2",
     "react": "~16.9.0",
     "react-dom": "~16.9.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.0.tar.gz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@expo/vector-icons": "~10.0.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
-    "@fortawesome/react-native-fontawesome": "^0.2.3",
     "@react-native-community/masked-view": "0.1.5",
     "@react-navigation/bottom-tabs": "^5.2.5",
     "@react-navigation/native": "^5.1.4",

--- a/screens/DetailsScreen.js
+++ b/screens/DetailsScreen.js
@@ -41,7 +41,11 @@ export default function DetailsScreen({ route }) {
           </View>
         </View>
         <View styles={styles.actionButtonContainer}>
-          <Button title='Visit our website' buttonStyle={styles.actionButton} />
+          <Button
+            title='Visit our website'
+            buttonStyle={styles.actionButton}
+            titleStyle={styles.actionButtonTitleStyle}
+          />
         </View>
         <Text style={styles.sectionTitle}>Current Services</Text>
         <View style={styles.serviceTilesContainer}>
@@ -142,6 +146,9 @@ const styles = StyleSheet.create({
     backgroundColor: "#6979F8",
     borderRadius: 8,
     marginBottom: 20,
+  },
+  actionButtonTitleStyle: {
+    fontSize: 16,
   },
   sectionParagraph: {
     marginBottom: 10,

--- a/screens/DetailsScreen.js
+++ b/screens/DetailsScreen.js
@@ -8,7 +8,6 @@ import {
   ScrollView,
 } from "react-native";
 import { Button } from "react-native-elements";
-import { dummyBusiness } from "../data/businesses";
 import { capitalize } from "lodash";
 
 export default function DetailsScreen({ route }) {
@@ -151,12 +150,15 @@ const styles = StyleSheet.create({
     color: "#1D1F24",
   },
   serviceTilesContainer: {
-    marginVertical: 25,
+    flexWrap: "wrap",
     flex: 1,
     flexDirection: "row",
+    marginTop: 20,
+    marginBottom: 15,
   },
   serviceTileBox: {
     marginRight: 10,
+    marginBottom: 10,
     paddingHorizontal: 15,
     paddingVertical: 8,
     backgroundColor: "#6CD4C4",

--- a/screens/DetailsScreen.js
+++ b/screens/DetailsScreen.js
@@ -1,41 +1,64 @@
-import React from 'react';
+import React from "react";
 import { StyleSheet, Text, Image, View, ScrollView } from "react-native";
-import { Button } from 'react-native-elements';
-import { dummyBusiness } from "../data/businesses"
+import { Button } from "react-native-elements";
+import { dummyBusiness } from "../data/businesses";
 import { capitalize } from "lodash";
 
 export default function DetailsScreen({ route }) {
-  const { business } = route.params
+  const { business } = route.params;
   return (
     <ScrollView style={styles.container}>
-      <Image style={styles.headerImage} source={{ uri: 'https://www.adpstore.com.au/wp-content/uploads/2017/08/shop-layout-1440x961.jpg' }} />
+      <Image
+        style={styles.headerImage}
+        source={{
+          uri:
+            "https://www.adpstore.com.au/wp-content/uploads/2017/08/shop-layout-1440x961.jpg",
+        }}
+      />
       <View style={styles.paddingContainer}>
         <View style={styles.titleContainer}>
-          <Image style={styles.logoImage} source={{ uri: 'https://carrythroughcovid.s3-ap-southeast-2.amazonaws.com/icons/cheeseburger.png' }} />
+          <Image
+            style={styles.logoImage}
+            source={{
+              uri:
+                "https://carrythroughcovid.s3-ap-southeast-2.amazonaws.com/icons/cheeseburger.png",
+            }}
+          />
           <View style={styles.titleDetailsContainer}>
             <Text style={styles.title}>{business.name}</Text>
-            <Text style={styles.subTitle}>{capitalize(business.categories[0].name)} / {business.suburb}</Text>
+            <Text style={styles.subTitle}>
+              {capitalize(business.categories[0].name)} / {business.suburb}
+            </Text>
           </View>
         </View>
-        <Button title="Website" buttonStyle={styles.actionButton} />
+        <Button title='Website' buttonStyle={styles.actionButton} />
       </View>
       <View style={styles.paddingContainer}>
-        <View>
-          <Text style={styles.sectionTitle}>CURRENT SERVICES</Text>
-          <Text style={styles.sectionParagraph}>
-            {business.offerings.map(offering => capitalize(offering.name)).join(", ")}
-          </Text>
+        <Text style={styles.sectionTitle}>Current Services</Text>
+        <View style={styles.serviceTilesContainer}>
+          {business.offerings.map(offering => {
+            return (
+              <View style={styles.serviceTileBox}>
+                <Text style={styles.serviceTileText}>
+                  {capitalize(offering.name)}
+                </Text>
+              </View>
+            );
+          })}
         </View>
         <View>
           <Text style={styles.sectionTitle}>DETAILS</Text>
           <Text style={styles.sectionParagraph}>
-            Here are the details about the particular offering from the store. It will just be free text for them to describe the offerings above.
+            Here are the details about the particular offering from the store.
+            It will just be free text for them to describe the offerings above.
           </Text>
         </View>
         <View>
           <Text style={styles.sectionTitle}>ABOUT</Text>
           <Text style={styles.sectionParagraph}>
-            Business owners will be asked to add info about their business, and this is an opportunity to tell their story and connect with the community.
+            Business owners will be asked to add info about their business, and
+            this is an opportunity to tell their story and connect with the
+            community.
           </Text>
         </View>
       </View>
@@ -48,7 +71,7 @@ DetailsScreen.navigationOptions = {};
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
+    backgroundColor: "#fff",
     paddingTop: 0,
   },
   paddingContainer: {
@@ -59,9 +82,9 @@ const styles = StyleSheet.create({
     fontSize: 30,
   },
   headerImage: {
-    width: '100%',
+    width: "100%",
     height: 240,
-    resizeMode: 'cover',
+    resizeMode: "cover",
   },
   logoImage: {
     width: 50,
@@ -69,13 +92,13 @@ const styles = StyleSheet.create({
   },
   titleContainer: {
     paddingTop: 50,
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
     paddingBottom: 20,
   },
   titleDetailsContainer: {
-    display: 'flex',
+    display: "flex",
     paddingLeft: 10,
   },
   title: {
@@ -85,15 +108,32 @@ const styles = StyleSheet.create({
     fontSize: 15,
   },
   sectionTitle: {
-    color: '#9060EB',
+    color: "#9060EB",
     fontWeight: "bold",
     paddingTop: 15,
     paddingBottom: 5,
+    textTransform: "uppercase",
   },
   actionButton: {
-    backgroundColor: '#6979F8',
+    backgroundColor: "#6979F8",
   },
   sectionParagraph: {
     fontSize: 16,
+  },
+  serviceTilesContainer: {
+    flex: 1,
+    flexDirection: "row",
+  },
+  serviceTileBox: {
+    marginRight: 5,
+    paddingHorizontal: 15,
+    paddingVertical: 8,
+    backgroundColor: "#6CD4C4",
+    borderRadius: 20,
+  },
+  serviceTileText: {
+    fontSize: 14,
+    fontWeight: "bold",
+    color: "#FFFFFF",
   },
 });

--- a/screens/DetailsScreen.js
+++ b/screens/DetailsScreen.js
@@ -51,7 +51,7 @@ export default function DetailsScreen({ route }) {
         <View style={styles.serviceTilesContainer}>
           {business.offerings.map(offering => {
             return (
-              <View style={styles.serviceTileBox}>
+              <View style={styles.serviceTileBox} key={offering.name}>
                 <Text style={styles.serviceTileText}>
                   {capitalize(offering.name)}
                 </Text>

--- a/screens/DetailsScreen.js
+++ b/screens/DetailsScreen.js
@@ -1,5 +1,12 @@
 import React from "react";
-import { StyleSheet, Text, Image, View, ScrollView } from "react-native";
+import {
+  Dimensions,
+  StyleSheet,
+  Text,
+  Image,
+  View,
+  ScrollView,
+} from "react-native";
 import { Button } from "react-native-elements";
 import { dummyBusiness } from "../data/businesses";
 import { capitalize } from "lodash";
@@ -17,23 +24,26 @@ export default function DetailsScreen({ route }) {
       />
       <View style={styles.paddingContainer}>
         <View style={styles.titleContainer}>
-          <Image
-            style={styles.logoImage}
-            source={{
-              uri:
-                "https://carrythroughcovid.s3-ap-southeast-2.amazonaws.com/icons/cheeseburger.png",
-            }}
-          />
+          <View style={styles.logoImageContainer}>
+            <Image
+              style={styles.logoImage}
+              source={{
+                uri:
+                  "https://carrythroughcovid.s3-ap-southeast-2.amazonaws.com/icons/cheeseburger.png",
+              }}
+            />
+          </View>
           <View style={styles.titleDetailsContainer}>
             <Text style={styles.title}>{business.name}</Text>
             <Text style={styles.subTitle}>
-              {capitalize(business.categories[0].name)} / {business.suburb}
+              {capitalize(business.categories[0].name)} &middot;{" "}
+              {business.suburb}
             </Text>
           </View>
         </View>
-        <Button title='Website' buttonStyle={styles.actionButton} />
-      </View>
-      <View style={styles.paddingContainer}>
+        <View styles={styles.actionButtonContainer}>
+          <Button title='Visit our website' buttonStyle={styles.actionButton} />
+        </View>
         <Text style={styles.sectionTitle}>Current Services</Text>
         <View style={styles.serviceTilesContainer}>
           {business.offerings.map(offering => {
@@ -73,10 +83,10 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: "#fff",
     paddingTop: 0,
+    width: Dimensions.get("window").width,
   },
   paddingContainer: {
-    paddingLeft: 20,
-    paddingRight: 20,
+    paddingHorizontal: 20,
   },
   textHeading: {
     fontSize: 30,
@@ -86,26 +96,39 @@ const styles = StyleSheet.create({
     height: 240,
     resizeMode: "cover",
   },
+  logoImageContainer: {
+    backgroundColor: "#F2F2F2",
+    borderRadius: 50,
+    padding: 18,
+    width: 60,
+    height: 60,
+  },
   logoImage: {
-    width: 50,
-    height: 50,
+    width: 24,
+    height: 24,
   },
   titleContainer: {
-    paddingTop: 50,
-    display: "flex",
+    alignItems: "stretch",
+    flexWrap: "wrap",
     flexDirection: "row",
-    alignItems: "center",
-    paddingBottom: 20,
+    alignContent: "stretch",
+    paddingTop: 50,
+    marginBottom: 30,
   },
   titleDetailsContainer: {
-    display: "flex",
-    paddingLeft: 10,
+    height: "100%",
+    width: "80%",
+    marginLeft: 10,
+    paddingRight: 20,
   },
   title: {
     fontSize: 25,
+    fontWeight: "bold",
+    marginBottom: 3,
   },
   subTitle: {
     fontSize: 15,
+    color: "#A5A5A7",
   },
   sectionTitle: {
     color: "#9060EB",
@@ -115,17 +138,25 @@ const styles = StyleSheet.create({
     textTransform: "uppercase",
   },
   actionButton: {
+    paddingTop: 10,
+    paddingBottom: 12,
     backgroundColor: "#6979F8",
+    borderRadius: 8,
+    marginBottom: 20,
   },
   sectionParagraph: {
+    marginBottom: 10,
     fontSize: 16,
+    lineHeight: 24,
+    color: "#1D1F24",
   },
   serviceTilesContainer: {
+    marginVertical: 25,
     flex: 1,
     flexDirection: "row",
   },
   serviceTileBox: {
-    marginRight: 5,
+    marginRight: 10,
     paddingHorizontal: 15,
     paddingVertical: 8,
     backgroundColor: "#6CD4C4",

--- a/screens/DiscoverScreen.js
+++ b/screens/DiscoverScreen.js
@@ -60,8 +60,14 @@ export default function DiscoverScreen({ navigation }) {
   );
 }
 
-DiscoverScreen.navigationOptions = {
-  header: null,
+DiscoverScreen.navigationOptions = () => {
+  return {
+    tabBarOptions: { showLabel: false },
+    tabBarOptions: {
+      activeTintColor: "#1A051D",
+      inactiveTintColor: "#CCCCCC",
+    },
+  };
 };
 
 const styles = StyleSheet.create({

--- a/screens/DiscoverScreen.js
+++ b/screens/DiscoverScreen.js
@@ -5,26 +5,39 @@ import {
   View,
   Text,
   SafeAreaView,
-  TouchableOpacity
+  TouchableOpacity,
 } from "react-native";
 import { Input, Divider } from "react-native-elements";
 
 import CategoryTile from "../components/CategoryTile";
 import { categories } from "../data/categories";
 
+import { FontAwesomeIcon } from "@fortawesome/react-native-fontawesome";
+import { faSearch } from "@fortawesome/free-solid-svg-icons";
+
 export default function DiscoverScreen({ navigation }) {
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView style={styles.scrollContainer}>
-        <Input
-          placeholder="Search by location or business name"
-          onSubmitEditing={event =>
-            navigation.navigate("SearchResults", {
-              searchInput: event.nativeEvent.text
-            })
-          }
-        />
-        <Divider style={styles.divider} />
+        <View style={styles.inputContainer}>
+          <Input
+            placeholder='Search by location or business name'
+            onSubmitEditing={event =>
+              navigation.navigate("SearchResults", {
+                searchInput: event.nativeEvent.text,
+              })
+            }
+            leftIcon={() => {
+              return <FontAwesomeIcon icon={faSearch} color={"#3F3356"} />;
+            }}
+            leftIconContainerStyle={styles.leftIconContainerStyle}
+            inputStyle={styles.inputStyle}
+            inputContainerStyle={styles.inputContainerStyle}
+          />
+        </View>
+      </ScrollView>
+      <Divider style={styles.divider} />
+      <ScrollView style={styles.scrollContainer}>
         <Text style={styles.sectionTitle}>Take a Browse</Text>
         <Text style={styles.textHeading}>Explore Categories</Text>
         <View style={styles.categoryContainer}>
@@ -47,44 +60,62 @@ export default function DiscoverScreen({ navigation }) {
 }
 
 DiscoverScreen.navigationOptions = {
-  header: null
+  header: null,
 };
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#fff"
+    backgroundColor: "#fff",
+  },
+  inputContainer: {
+    borderRadius: 3,
+    borderWidth: 1,
+    borderColor: "#ECEBED",
+  },
+  inputContainerStyle: {
+    paddingVertical: 2,
+    borderWidth: 0,
+    borderColor: "transparent",
+  },
+  leftIconContainerStyle: {
+    marginRight: 8,
+    marginLeft: 5,
+  },
+  inputStyle: {
+    borderWidth: 0,
+    fontSize: 15,
   },
   scrollContainer: {
-    padding: 20
+    paddingHorizontal: 20,
+    paddingVertical: 35,
   },
   textHeading: {
     fontSize: 25,
-    marginBottom: 15
+    marginBottom: 15,
   },
   sectionTitle: {
     color: "#9060EB",
     fontWeight: "bold",
     paddingTop: 15,
     paddingBottom: 5,
-    textTransform: "uppercase"
+    textTransform: "uppercase",
   },
   divider: {
-    marginTop: 20,
-    marginBottom: 20
+    backgroundColor: "#CCCCCC",
   },
   categoryContainer: {
     display: "flex",
     flexDirection: "row",
     flexWrap: "wrap",
     justifyContent: "space-between",
-    padding: 3
+    padding: 3,
   },
   categoryIcon: {
     minWidth: "48%",
     shadowColor: "#000",
     shadowOffset: { width: 0, height: 0 },
     shadowOpacity: 0.1,
-    shadowRadius: 10
-  }
+    shadowRadius: 10,
+  },
 });

--- a/screens/DiscoverScreen.js
+++ b/screens/DiscoverScreen.js
@@ -27,9 +27,7 @@ export default function DiscoverScreen({ navigation }) {
               })
             }
             leftIcon={() => {
-              return (
-                <FeatherIcon name='search' color={"#3F3356"} height={30} />
-              );
+              return <FeatherIcon name='search' color={"#3F3356"} size={20} />;
             }}
             leftIconContainerStyle={styles.leftIconContainerStyle}
             inputStyle={styles.inputStyle}

--- a/screens/DiscoverScreen.js
+++ b/screens/DiscoverScreen.js
@@ -12,8 +12,7 @@ import { Input, Divider } from "react-native-elements";
 import CategoryTile from "../components/CategoryTile";
 import { categories } from "../data/categories";
 
-import { FontAwesomeIcon } from "@fortawesome/react-native-fontawesome";
-import { faSearch } from "@fortawesome/free-solid-svg-icons";
+import FeatherIcon from "react-native-vector-icons/Feather";
 
 export default function DiscoverScreen({ navigation }) {
   return (
@@ -28,7 +27,9 @@ export default function DiscoverScreen({ navigation }) {
               })
             }
             leftIcon={() => {
-              return <FontAwesomeIcon icon={faSearch} color={"#3F3356"} />;
+              return (
+                <FeatherIcon name='search' color={"#3F3356"} height={30} />
+              );
             }}
             leftIconContainerStyle={styles.leftIconContainerStyle}
             inputStyle={styles.inputStyle}

--- a/screens/SearchResultsScreen.js
+++ b/screens/SearchResultsScreen.js
@@ -4,13 +4,14 @@ import {
   Text,
   View,
   ScrollView,
-  TouchableOpacity
+  TouchableOpacity,
 } from "react-native";
 import { Input } from "react-native-elements";
 import RNPickerSelect from "react-native-picker-select";
+import { capitalize } from "lodash";
 
 import { FontAwesomeIcon } from "@fortawesome/react-native-fontawesome";
-import { faSortDown } from "@fortawesome/free-solid-svg-icons";
+import { faSearch, faSortDown } from "@fortawesome/free-solid-svg-icons";
 
 import ResultTile from "../components/ResultTile";
 
@@ -19,6 +20,7 @@ export default function SearchResultsScreen({ navigation, route }) {
   const { category } = navigation.dangerouslyGetState().routes[1].params || "";
   const [businesses, setBusinesses] = useState([]);
   const [filteredBusinesses, setFilteredBusinesses] = useState([]);
+  const [dropdownCategory, setDropdownCategory] = useState(category || "");
 
   const categoryData = [
     { label: "All categories", value: "" },
@@ -26,7 +28,7 @@ export default function SearchResultsScreen({ navigation, route }) {
     { label: "Retail", value: "retail" },
     { label: "Health and Wellbeing", value: "health and wellbeing" },
     { label: "Services", value: "services" },
-    { label: "Other", value: "other" }
+    { label: "Other", value: "other" },
   ];
 
   const nearestToMeData = [{ label: "Date added", value: "date-added" }];
@@ -57,6 +59,7 @@ export default function SearchResultsScreen({ navigation, route }) {
   const handleCategoryChange = selectedCategory => {
     // If there's a selected category, filter on its name
     // Else return all businesses
+    setDropdownCategory({ label: selectedCategory, value: selectedCategory });
     if (selectedCategory) {
       const filtered = businesses.filter(business => {
         return business.categories[0].name == selectedCategory.toLowerCase();
@@ -70,12 +73,24 @@ export default function SearchResultsScreen({ navigation, route }) {
   return (
     <ScrollView style={styles.container}>
       <View style={styles.paddingContainer}>
-        <Input placeholder="Search for a business" />
+        <View style={styles.inputContainer}>
+          <Input
+            placeholder='Search by location or business name'
+            leftIcon={() => {
+              return <FontAwesomeIcon icon={faSearch} color={"#3F3356"} />;
+            }}
+            leftIconContainerStyle={styles.leftIconContainerStyle}
+            inputStyle={styles.inputStyle}
+            inputContainerStyle={styles.inputContainerStyle}
+          >
+            {searchInput ? searchInput : ""}
+          </Input>
+        </View>
         <View style={styles.dropDownContainer}>
           <View style={styles.dropDown}>
             <RNPickerSelect
               placeholder={{}}
-              placeholderTextColor="#3F3356"
+              placeholderTextColor='#3F3356'
               items={categoryData}
               onValueChange={value => handleCategoryChange(value)}
               Icon={() => {
@@ -87,7 +102,7 @@ export default function SearchResultsScreen({ navigation, route }) {
           <View style={styles.dropDown}>
             <RNPickerSelect
               placeholder={{ label: "Nearest to me", value: "nearest-to-me" }}
-              placeholderTextColor="#3F3356"
+              placeholderTextColor='#3F3356'
               items={nearestToMeData}
               onValueChange={value => console.log(value)}
               Icon={() => {
@@ -99,7 +114,10 @@ export default function SearchResultsScreen({ navigation, route }) {
         </View>
         <Text style={styles.resultsText}>
           {filteredBusinesses.length}{" "}
-          {filteredBusinesses.length === 1 ? "result" : "results"}
+          {filteredBusinesses.length === 1 ? "result" : "results"}{" "}
+          {dropdownCategory.label
+            ? `for ${capitalize(dropdownCategory.label)}`
+            : ``}
         </Text>
         {filteredBusinesses.length > 0 &&
           filteredBusinesses.map(business => (
@@ -118,7 +136,7 @@ export default function SearchResultsScreen({ navigation, route }) {
       </View>
     </ScrollView>
   );
-}
+};
 
 SearchResultsScreen.navigationOptions = {};
 
@@ -126,7 +144,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: "#fff",
-    paddingTop: 0
+    paddingTop: 0,
   },
   dropDown: {
     fontSize: 16,
@@ -134,26 +152,48 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: "#ECEBED",
     borderRadius: 3,
-    width: "49%"
+    width: "49%",
   },
   dropDownContainer: {
     flex: 1,
     flexDirection: "row",
     flexWrap: "wrap",
     justifyContent: "space-between",
-    alignItems: "flex-start"
+    alignItems: "flex-start",
+    marginTop: 10,
+  },
+  inputContainer: {
+    marginTop: 15,
+    borderRadius: 3,
+    borderWidth: 1,
+    borderColor: "#ECEBED",
+  },
+  inputContainerStyle: {
+    paddingVertical: 2,
+    borderWidth: 0,
+    borderColor: "transparent",
+  },
+  leftIconContainerStyle: {
+    marginRight: 8,
+    marginLeft: 5,
+  },
+  inputStyle: {
+    borderWidth: 0,
+    fontSize: 15,
   },
   paddingContainer: {
     paddingLeft: 20,
-    paddingRight: 20
+    paddingRight: 20,
   },
   result: {
     paddingBottom: 10,
-    paddingTop: 10
+    paddingTop: 10,
   },
   resultsText: {
-    paddingTop: 10
-  }
+    marginTop: 25,
+    marginBottom: 10,
+    color: "#787187",
+  },
 });
 
 const pickerSelectStyles = {
@@ -161,13 +201,14 @@ const pickerSelectStyles = {
     color: "#3F3356",
     paddingTop: 15,
     paddingHorizontal: 10,
-    paddingBottom: 14
+    paddingBottom: 14,
   },
   inputAndroid: {
-    color: "#3F3356"
+    color: "#3F3356",
   },
   iconContainer: {
     right: 12,
-    top: 12
-  }
+    top: 12,
+  },
 };
+


### PR DESCRIPTION
## High-level overview

- Add Prettier 💅 💇💃 
- General style improvements
   - Fix padding and search bar on Discover Screen
   - Fix search bar and results shadows on SRP
   - Add styles to services boxes on Details Screen
   - Fix wrapping of title on Details Screen
   - Add tab bar icons

## Callouts

- 👎 Some repeated code for the search bar on Discover and SRP – to be fixed in a refactor PR
- 👍 Removed FontAwesome in place of Feather icons as per Aaron's notes
- 👍 Jolly's suggestion is use Feather for GUI and FontAwesome for categories in future

## Preview

### Discover Screen

<img width="584" alt="Screen Shot 2020-04-04 at 5 21 58 pm" src="https://user-images.githubusercontent.com/16424236/78420215-db9fa200-7698-11ea-937d-c74cf9a54f57.png">

### Search Results Screen

<img width="584" alt="Screen Shot 2020-04-04 at 5 22 00 pm" src="https://user-images.githubusercontent.com/16424236/78420219-e2c6b000-7698-11ea-88c0-f78ee2d2e65b.png">

### Details Screen

<img width="584" alt="Screen Shot 2020-04-04 at 5 18 09 pm" src="https://user-images.githubusercontent.com/16424236/78420161-5caa6980-7698-11ea-9640-7a7766b0a516.png">
