### PR TITLE
Add T&C section to About page

### DIFF
--- a/screens/AboutScreen.js
+++ b/screens/AboutScreen.js
@@ -84,7 +84,7 @@ const AboutScreen = () => {
       <View style={criticalSectionStyle}>
         <Text style={lightSectionTitleStyle}>Terms and Conditions</Text>
         <Text style={darkSectionTextStyle}>
-          Click{" "}
+          View our terms and conditions{" "}
           <Text
             style={styles.sectionHyperlink}
             onPress={() =>
@@ -94,8 +94,8 @@ const AboutScreen = () => {
             }
           >
             here
-          </Text>{" "}
-          to view our terms and conditions.
+          </Text>
+          .
         </Text>
       </View>
     </ScrollView>

--- a/screens/AboutScreen.js
+++ b/screens/AboutScreen.js
@@ -1,28 +1,55 @@
 import React from "react";
-import { ScrollView, View, Text, StyleSheet, Image } from "react-native";
+import {
+  Image,
+  Linking,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
 import Constants from "expo-constants";
 import colours from "../utils/colours";
 
 const AboutScreen = () => {
+  // Dark background, light text
   const darkSectionStyle = addStyleTo("sectionContainer", {
     backgroundColor: colours.brand,
   });
 
-  const lightSectionStyle = addStyleTo("sectionContainer", {
-    backgroundColor: colours.backgroundGrey,
-  });
-
-  const lightSectionTextStyle = addStyleTo("sectionText", {
-    color: "white",
+  const darkSectionTitleStyle = addStyleTo("sectionTitle", {
+    backgroundColor: colours.brand,
   });
 
   const darkSectionTextStyle = addStyleTo("sectionText", {
-    color: colours.brandAccent3,
+    color: colours.backgroundWhite,
   });
 
-  const lightSectionTextBoldStyle = addStyleTo("sectionText", {
+  const darkSectionTextBoldStyle = addStyleTo("sectionText", {
     color: "white",
     fontWeight: "bold",
+    fontFamily: "Oswald Regular",
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    marginVertical: 16,
+    color: colours.textUiPrimary,
+  });
+
+  // Light background, dark text
+  const lightSectionStyle = addStyleTo("sectionContainer", {
+    backgroundColor: colours.backgroundWhite,
+  });
+
+  const lightSectionTitleStyle = addStyleTo("sectionTitle", {
+    color: colours.textUiPrimary,
+  });
+
+  const lightSectionTextStyle = addStyleTo("sectionText", {
+    color: colours.brand,
+  });
+
+  // Critical background (red)
+  const criticalSectionStyle = addStyleTo("sectionContainer", {
+    backgroundColor: colours.statusCritical,
   });
 
   return (
@@ -32,12 +59,12 @@ const AboutScreen = () => {
           style={styles.image}
           source={require("../assets/images/target.png")}
         />
-        <Text style={styles.sectionTitle}>Our Mission</Text>
-        <Text style={lightSectionTextStyle}>
+        <Text style={darkSectionTitleStyle}>Our Mission</Text>
+        <Text style={darkSectionTextStyle}>
           We want to help keep small businesses afloat and enable community
           support through technology.
         </Text>
-        <Text style={lightSectionTextBoldStyle}>
+        <Text style={darkSectionTextBoldStyle}>
           Completely free to use, forever.
         </Text>
       </View>
@@ -46,12 +73,29 @@ const AboutScreen = () => {
           style={styles.image}
           source={require("../assets/images/hands-people.png")}
         />
-        <Text style={styles.sectionTitle}>Who We Are</Text>
-        <Text style={darkSectionTextStyle}>
+        <Text style={lightSectionTitleStyle}>Who We Are</Text>
+        <Text style={lightSectionTextStyle}>
           We’re a group of volunteers taking action to support small businesses.
           We realised that it can be tricky for customers to keep across all the
           latest updates from their favourite local businesses. So we thought
           we’d volunteer our skills and passion to help fill that gap.
+        </Text>
+      </View>
+      <View style={criticalSectionStyle}>
+        <Text style={lightSectionTitleStyle}>Terms and Conditions</Text>
+        <Text style={darkSectionTextStyle}>
+          Click{" "}
+          <Text
+            style={styles.sectionHyperlink}
+            onPress={() =>
+              Linking.openURL(
+                "https://carrythroughcovid.s3-ap-southeast-2.amazonaws.com/ctc_terms.pdf",
+              )
+            }
+          >
+            here
+          </Text>{" "}
+          to view our terms and conditions.
         </Text>
       </View>
     </ScrollView>
@@ -64,7 +108,9 @@ const styles = StyleSheet.create({
     marginTop: Constants.statusBarHeight,
   },
   sectionContainer: {
-    paddingVertical: 100,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingVertical: 42,
     paddingHorizontal: 30,
     display: "flex",
   },
@@ -73,14 +119,25 @@ const styles = StyleSheet.create({
     height: 60,
   },
   sectionTitle: {
+    textAlign: "center",
     fontFamily: "Oswald Regular",
     fontSize: 16,
     textTransform: "uppercase",
-    paddingVertical: 16,
+    paddingTop: 12,
+    paddingBottom: 8,
+    letterSpacing: 1,
+    color: colours.textUiPrimary,
   },
   sectionText: {
+    textAlign: "center",
+    lineHeight: 24,
     fontFamily: "Lato",
-    paddingTop: 8,
+    fontSize: 16,
+  },
+  sectionHyperlink: {
+    textDecorationLine: "underline",
+    textDecorationStyle: "solid",
+    textDecorationColor: colours.backgroundWhite,
   },
 });
 


### PR DESCRIPTION
## Context

- Add a link to [Terms and Conditions](https://carrythroughcovid.s3-ap-southeast-2.amazonaws.com/ctc_terms.pdf) at the bottom of the About page
- Fix About page styles to match designs

## Testing strategy

- Check link is accessible/clickable via iPhone
- Navigate back to CTC after viewing PDF

## Screenshot

<img width="559" alt="Screen Shot 2020-04-20 at 8 23 26 pm" src="https://user-images.githubusercontent.com/16424236/79741564-d1420100-8344-11ea-9661-07d77fa9326c.png">
