### PR TITLE
Create Purchase screen flow

### DIFF
--- a/navigation/TabNavigator.js
+++ b/navigation/TabNavigator.js
@@ -7,6 +7,7 @@ import DiscoverScreen from "../screens/DiscoverScreen";
 import SearchResultsScreen from "../screens/SearchResultsScreen";
 import DetailsScreen from "../screens/DetailsScreen";
 import AboutScreen from "../screens/AboutScreen";
+import PurchaseScreen from "../screens/PurchaseScreen";
 
 import FeatherIcon from "react-native-vector-icons/Feather";
 
@@ -31,6 +32,13 @@ function DiscoverStackScreen() {
       <DiscoverStack.Screen
         name='Details'
         component={DetailsScreen}
+        options={{
+          headerTitle: "",
+        }}
+      />
+      <DiscoverStack.Screen
+        name='Purchase'
+        component={PurchaseScreen}
         options={{
           headerTitle: "",
         }}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "expo-constants": "~8.0.0",
     "expo-device": "~2.0.0",
     "expo-font": "~8.0.0",
+    "expo-image-picker": "~8.0.1",
     "expo-web-browser": "~8.0.0",
     "lodash": "^4.17.15",
     "prettier": "^2.0.2",

--- a/screens/PurchaseScreen.js
+++ b/screens/PurchaseScreen.js
@@ -12,7 +12,7 @@ import colours from "../utils/colours";
 const PurchaseScreen = ({ route }) => {
   const { business } = route.params;
 
-  const [product, onChangeProduct] = useState("");
+  const [productDescription, onChangeProductDescription] = useState("");
   const [comment, onChangeComment] = useState("");
   const [purchaseImage, onChangePurchaseImage] = useState(null);
 
@@ -45,6 +45,10 @@ const PurchaseScreen = ({ route }) => {
   };
 
   const submitPurchase = () => {
+    // TODO (Jac):
+    //  - Gather product description, comment, and image
+    //  - Submit to server
+    //  - Transition to social/thank you page
     console.log("submitPurchase");
   };
 
@@ -74,8 +78,8 @@ const PurchaseScreen = ({ route }) => {
         <View style={styles.inputContainer}>
           <Input
             placeholder='Almond latte'
-            onChangeText={text => onChangeProduct(text)}
-            value={product}
+            onChangeText={text => onChangeProductDescription(text)}
+            value={productDescription}
           />
         </View>
         <Text style={styles.sectionTitle}>
@@ -83,7 +87,7 @@ const PurchaseScreen = ({ route }) => {
         </Text>
         <View style={styles.inputContainer}>
           <Input
-            placeholder='Best value!'
+            placeholder='Best value for money'
             onChangeText={text => onChangeComment(text)}
             value={comment}
           />
@@ -154,7 +158,7 @@ const styles = StyleSheet.create({
     borderRadius: 3,
   },
   inputContainer: {
-    backgroundColor: "#fff",
+    backgroundColor: colours.backgroundWhite,
     borderRadius: 4,
     borderWidth: 1,
     borderColor: colours.textUiTertiary,

--- a/screens/PurchaseScreen.js
+++ b/screens/PurchaseScreen.js
@@ -1,0 +1,45 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import Input from "../components/Input";
+import { TouchableOpacity } from "react-native-gesture-handler";
+
+const PurchaseScreen = ({ navigate }) => {
+  return (
+    <ScrollView>
+      <View>
+        <Text>Company name</Text>
+      </View>
+      <View>
+        <Text>What product/service did you purchase?</Text>
+        <Input />
+      </View>
+      <View>
+        <Text>Add comments about your purchase</Text>
+      </View>
+      <View>
+        <Text>Add an image of the purchase</Text>
+        <TouchableOpacity onPress={() => console.log("Upload image")}>
+          <Text>Upload</Text>
+        </TouchableOpacity>
+      </View>
+      <View>
+        <Text>This purchase is worth 10 Carry points.</Text>
+        <Text>This purchase will unlock the Super Supporter badge.</Text>
+      </View>
+      <View>
+        <TouchableOpacity onPress={() => console.log("Submit image")}>
+          <Text>Submit</Text>
+        </TouchableOpacity>
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    display: "flex",
+    marginTop: Constants.statusBarHeight,
+  },
+});
+
+export default PurchaseScreen;

--- a/screens/PurchaseScreen.js
+++ b/screens/PurchaseScreen.js
@@ -1,35 +1,51 @@
 import React from "react";
-import { StyleSheet, View } from "react-native";
+import { Image, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Button } from "react-native-elements";
+import { capitalize } from "lodash";
 import Input from "../components/Input";
-import { TouchableOpacity } from "react-native-gesture-handler";
+import Constants from "expo-constants";
+import colours from "../utils/colours";
 
-const PurchaseScreen = ({ navigate }) => {
+const PurchaseScreen = ({ route }) => {
+  const { business } = route.params;
+
   return (
-    <ScrollView>
-      <View>
-        <Text>Company name</Text>
+    <ScrollView style={styles.container}>
+      <View style={styles.paddingContainer}>
+        <View style={styles.titleContainer}>
+          {!!business.imgix_images.logo && (
+            <Image
+              style={styles.logoImage}
+              source={{ uri: business.imgix_images.logo }}
+            />
+          )}
+          <View style={styles.titleDetailsContainer}>
+            <Text style={styles.title}>{business.name}</Text>
+            <Text style={styles.subTitle}>
+              {capitalize(business.categories[0].name)}
+              {business.suburb ? ` · ${business.suburb}` : ``}
+            </Text>
+          </View>
+        </View>
       </View>
-      <View>
+      <View style={styles.paddingContainer}>
         <Text>What product/service did you purchase?</Text>
         <Input />
-      </View>
-      <View>
         <Text>Add comments about your purchase</Text>
-      </View>
-      <View>
+        <Input />
         <Text>Add an image of the purchase</Text>
-        <TouchableOpacity onPress={() => console.log("Upload image")}>
-          <Text>Upload</Text>
-        </TouchableOpacity>
-      </View>
-      <View>
+        <Button
+          style={styles.buttonUpload}
+          title='Upload'
+          onPress={() => console.log(business)}
+        />
         <Text>This purchase is worth 10 Carry points.</Text>
         <Text>This purchase will unlock the Super Supporter badge.</Text>
-      </View>
-      <View>
-        <TouchableOpacity onPress={() => console.log("Submit image")}>
-          <Text>Submit</Text>
-        </TouchableOpacity>
+        <Button
+          style={styles.buttonSubmit}
+          title='Submit'
+          onPress={() => console.log(business)}
+        />
       </View>
     </ScrollView>
   );
@@ -39,6 +55,35 @@ const styles = StyleSheet.create({
   container: {
     display: "flex",
     marginTop: Constants.statusBarHeight,
+  },
+  paddingContainer: {
+    paddingHorizontal: 20,
+  },
+  titleContainer: {
+    alignItems: "stretch",
+    flexWrap: "wrap",
+    flexDirection: "row",
+    alignContent: "stretch",
+    paddingTop: 50,
+    marginBottom: 30,
+  },
+  title: {
+    fontSize: 25,
+    fontWeight: "bold",
+    marginBottom: 3,
+    color: colours.textUiPrimary,
+  },
+  subTitle: {
+    fontSize: 15,
+    color: colours.textUiSecondary,
+  },
+  logoImage: {
+    width: 60,
+    height: 60,
+    borderRadius: 50,
+  },
+  buttonUpload: {
+    width: "50%",
   },
 });
 

--- a/screens/PurchaseScreen.js
+++ b/screens/PurchaseScreen.js
@@ -1,13 +1,52 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Image, ScrollView, StyleSheet, Text, View } from "react-native";
 import { Button } from "react-native-elements";
 import { capitalize } from "lodash";
 import Input from "../components/Input";
+import * as ImagePicker from "expo-image-picker";
+import * as Permissions from "expo-permissions";
+
 import Constants from "expo-constants";
 import colours from "../utils/colours";
 
 const PurchaseScreen = ({ route }) => {
   const { business } = route.params;
+
+  const [product, onChangeProduct] = useState("");
+  const [comment, onChangeComment] = useState("");
+  const [purchaseImage, onChangePurchaseImage] = useState(null);
+
+  useEffect(() => {
+    const _getPermissionAsync = async () => {
+      if (Constants.platform.ios) {
+        const { status } = await Permissions.askAsync(Permissions.CAMERA_ROLL);
+        if (status !== "granted") {
+          alert("Sorry, we need camera roll permissions to make this work!");
+        }
+      }
+    };
+    _getPermissionAsync();
+  }, []);
+
+  const uploadImage = async () => {
+    try {
+      let image = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.All,
+        allowsEditing: true,
+        aspect: [4, 3],
+        quality: 1,
+      });
+      if (!image.cancelled) {
+        onChangePurchaseImage({ image: image.uri });
+      }
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  const submitPurchase = () => {
+    console.log("submitPurchase");
+  };
 
   return (
     <ScrollView style={styles.container}>
@@ -29,22 +68,49 @@ const PurchaseScreen = ({ route }) => {
         </View>
       </View>
       <View style={styles.paddingContainer}>
-        <Text>What product/service did you purchase?</Text>
-        <Input />
-        <Text>Add comments about your purchase</Text>
-        <Input />
-        <Text>Add an image of the purchase</Text>
+        <Text style={styles.sectionTitle}>
+          What product/service did you purchase?
+        </Text>
+        <View style={styles.inputContainer}>
+          <Input
+            placeholder='Almond latte'
+            onChangeText={text => onChangeProduct(text)}
+            value={product}
+          />
+        </View>
+        <Text style={styles.sectionTitle}>
+          Add comments about your purchase
+        </Text>
+        <View style={styles.inputContainer}>
+          <Input
+            placeholder='Best value!'
+            onChangeText={text => onChangeComment(text)}
+            value={comment}
+          />
+        </View>
+        <Text style={styles.sectionTitle}>Add an image of the purchase</Text>
         <Button
-          style={styles.buttonUpload}
+          buttonStyle={[styles.actionButton, { width: "50%" }]}
           title='Upload'
-          onPress={() => console.log(business)}
+          onPress={uploadImage}
         />
-        <Text>This purchase is worth 10 Carry points.</Text>
-        <Text>This purchase will unlock the Super Supporter badge.</Text>
+        <View>
+          {purchaseImage && (
+            <Image source={{ uri: purchaseImage.image }} style={styles.image} />
+          )}
+        </View>
+        <View style={styles.sectionContainer}>
+          <Text style={styles.sectionParagraph}>
+            This purchase is worth 10 Carry points.
+          </Text>
+          <Text style={styles.sectionParagraph}>
+            This purchase will unlock the Super Supporter badge.
+          </Text>
+        </View>
         <Button
-          style={styles.buttonSubmit}
+          buttonStyle={styles.actionButton}
           title='Submit'
-          onPress={() => console.log(business)}
+          onPress={submitPurchase}
         />
       </View>
     </ScrollView>
@@ -54,7 +120,7 @@ const PurchaseScreen = ({ route }) => {
 const styles = StyleSheet.create({
   container: {
     display: "flex",
-    marginTop: Constants.statusBarHeight,
+    backgroundColor: colours.backgroundWhite,
   },
   paddingContainer: {
     paddingHorizontal: 20,
@@ -81,9 +147,39 @@ const styles = StyleSheet.create({
     width: 60,
     height: 60,
     borderRadius: 50,
+    marginRight: 15,
   },
-  buttonUpload: {
-    width: "50%",
+  actionButton: {
+    backgroundColor: colours.brand,
+    borderRadius: 3,
+  },
+  inputContainer: {
+    backgroundColor: "#fff",
+    borderRadius: 4,
+    borderWidth: 1,
+    borderColor: colours.textUiTertiary,
+  },
+  sectionTitle: {
+    color: colours.brand,
+    fontWeight: "normal",
+    paddingTop: 15,
+    paddingBottom: 5,
+    textTransform: "uppercase",
+    fontFamily: "Oswald Regular",
+    fontSize: 16,
+  },
+  sectionContainer: {
+    marginVertical: 10,
+  },
+  sectionParagraph: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: colours.textUiPrimary,
+  },
+  image: {
+    marginVertical: 10,
+    width: 200,
+    height: 200,
   },
 });
 


### PR DESCRIPTION
## High-level overview

This adds a new Purchase screen available via the business detail page to share a purchase made with that business. Users can include information about the product bought, any comments, and include an image from their phone's camera roll.

## Callouts

- Using Expo's [ImagePicker](https://docs.expo.io/versions/latest/sdk/imagepicker/) library, `expo-image-picker`
- New button on the `DetailsScreen` not included in this PR
- Overlapping styles between `DetailsScreen` and `PurchaseScreen` will require some refactoring
- No connection to backend yet (i.e. saving the data), submit button not functional
- Styles not finalised yet

## Screenshot

![purchase-flow](https://user-images.githubusercontent.com/16424236/81459813-fb207200-91e4-11ea-819b-1f98bd457b33.gif)
